### PR TITLE
add client hints for ssr

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -8,6 +8,7 @@ import type { AppLoadContext, EntryContext } from "@remix-run/cloudflare";
 import { RemixServer } from "@remix-run/react";
 import { isbot } from "isbot";
 import { renderToReadableStream } from "react-dom/server";
+import { NonceProvider } from "./utils/nonce-provider";
 
 const ABORT_DELAY = 5000;
 
@@ -23,13 +24,16 @@ export default async function handleRequest(
 ) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), ABORT_DELAY);
+  const nonce = crypto.randomUUID().replace(/-/g, "");
 
   const body = await renderToReadableStream(
-    <RemixServer
-      context={remixContext}
-      url={request.url}
-      abortDelay={ABORT_DELAY}
-    />,
+    <NonceProvider value={nonce}>
+      <RemixServer
+        context={remixContext}
+        url={request.url}
+        abortDelay={ABORT_DELAY}
+      />
+    </NonceProvider>,
     {
       signal: controller.signal,
       onError(error: unknown) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,11 +5,13 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/cloudflare";
+import type { LinksFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
 import styles from "./tailwind.css?url";
 
 import "./tailwind.css";
 import { Header } from "./components/header";
+import { ClientHintCheck, getHints } from "./utils/client-hints";
+import { useNonce } from "./utils/nonce-provider";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: styles },
@@ -25,12 +27,23 @@ export const links: LinksFunction = () => [
   },
 ];
 
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  return {
+    requestInfo: {
+      hints: getHints(request),
+    },
+  };
+};
+
 export function Layout({ children }: { children: React.ReactNode }) {
+  const nonce = useNonce();
+
   return (
     <html lang="en" className="dark">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <ClientHintCheck nonce={nonce} />
         <Meta />
         <Links />
       </head>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,10 @@
-import type { MetaFunction } from "@remix-run/cloudflare";
-import { Link } from "@remix-run/react";
+import { getHintUtils } from "@epic-web/client-hints";
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/cloudflare";
+import { Link, useLoaderData } from "@remix-run/react";
 import { motion } from "framer-motion";
 import { Button } from "~/components/ui/button";
+import { clientHint as timeZoneHint } from "@epic-web/client-hints/time-zone";
+import { getHints } from "~/utils/client-hints";
 
 export const meta: MetaFunction = () => {
   return [
@@ -14,9 +17,19 @@ export const meta: MetaFunction = () => {
   ];
 };
 
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { timeZone } = getHints(request);
+  const clientTime = new Date().toLocaleString("en-US", {
+    timeZone,
+    hour12: false,
+    hour: "numeric",
+  });
+
+  return { greeting: getGreeting(Number(clientTime)) };
+};
+
 export default function Index() {
-  const hourOfDay = new Date(Date.now()).getHours();
-  const greeting = getGreeting(hourOfDay);
+  const { greeting } = useLoaderData<typeof loader>();
 
   return (
     <div className="flex flex-col items-center mx-auto py-32 gap-20 max-w-3xl">
@@ -27,7 +40,7 @@ export default function Index() {
           transition={{ duration: 0.7, type: "spring" }}
           className="leading text-7xl font-bold text-pink-500"
         >
-          {greeting.msg}
+          {greeting}
         </motion.h1>
       </div>
       <div className="flex flex-col items-start gap-10">
@@ -54,11 +67,15 @@ export default function Index() {
           </div>
         </div>
         <div className="flex flex-col items-start gap-5">
-          <span>
+          <p>
             This website was built with Remix and Tailwind and deployed to
             Cloudflare Workers but I actually spend most of my time working in
             enterprise React apps
-          </span>
+          </p>
+          <p>
+            I've also been working on a concentrated liquidity market making bot
+            for Solana which has been running full time since August 2024.
+          </p>
           <Button
             variant="secondary"
             size="lg"
@@ -78,20 +95,13 @@ export default function Index() {
 }
 
 function getGreeting(hourOfDay: number) {
-  if (hourOfDay > 17 || hourOfDay < 4)
-    return {
-      msg: "Good evening",
-      url: "",
-    };
+  if (hourOfDay > 17 || hourOfDay < 4) {
+    return "Good evening";
+  }
 
-  if (hourOfDay >= 4 && hourOfDay < 12)
-    return {
-      msg: "Good morning",
-      url: "",
-    };
+  if (hourOfDay >= 4 && hourOfDay < 12) {
+    return "Good morning";
+  }
 
-  return {
-    msg: "Good afternoon",
-    url: "",
-  };
+  return "Good afternoon";
 }

--- a/app/utils/client-hints.tsx
+++ b/app/utils/client-hints.tsx
@@ -1,0 +1,39 @@
+import { getHintUtils } from "@epic-web/client-hints";
+import { subscribeToSchemeChange } from "@epic-web/client-hints/color-scheme";
+import { clientHint as timeZoneHint } from "@epic-web/client-hints/time-zone";
+import { useRevalidator } from "@remix-run/react";
+import * as React from "react";
+import { useOptionalRequestInfo, useRequestInfo } from "./request-info";
+
+const hintsUtils = getHintUtils({
+  timeZone: timeZoneHint,
+});
+
+export const { getHints } = hintsUtils;
+
+export function useHints() {
+  const requestInfo = useRequestInfo();
+  return requestInfo.hints;
+}
+
+export function useOptionalHints() {
+  const requestInfo = useOptionalRequestInfo();
+  return requestInfo?.hints;
+}
+
+export function ClientHintCheck({ nonce }: { nonce: string }) {
+  const { revalidate } = useRevalidator();
+  React.useEffect(
+    () => subscribeToSchemeChange(() => revalidate()),
+    [revalidate]
+  );
+
+  return (
+    <script
+      nonce={nonce}
+      dangerouslySetInnerHTML={{
+        __html: hintsUtils.getClientHintCheckScript(),
+      }}
+    />
+  );
+}

--- a/app/utils/nonce-provider.ts
+++ b/app/utils/nonce-provider.ts
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react";
+
+export const NonceContext = createContext<string>("");
+export const NonceProvider = NonceContext.Provider;
+export const useNonce = () => useContext(NonceContext);

--- a/app/utils/request-info.ts
+++ b/app/utils/request-info.ts
@@ -1,0 +1,15 @@
+import { useRouteLoaderData } from "@remix-run/react";
+
+export function useRequestInfo() {
+  const maybeRequestInfo = useOptionalRequestInfo();
+
+  if (!maybeRequestInfo) throw new Error("missing root request info");
+
+  return maybeRequestInfo;
+}
+
+export function useOptionalRequestInfo() {
+  const data = useRouteLoaderData("root");
+
+  return data?.requestInfo;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "my-remix-app",
       "dependencies": {
+        "@epic-web/client-hints": "^1.3.5",
         "@radix-ui/react-slot": "^1.1.0",
         "@remix-run/cloudflare": "^2.14.0",
         "@remix-run/react": "^2.14.0",
@@ -680,6 +681,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
       "dev": true
+    },
+    "node_modules/@epic-web/client-hints": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@epic-web/client-hints/-/client-hints-1.3.5.tgz",
+      "integrity": "sha512-tFIDxdU5NzN5Ak4gcDOPKkj6aF/qNMC0G+K58CTBZIx7CMSjCrxqhuiEbZBKGDAGJcsQLF5uKKlgs6mgqWmB7Q=="
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typegen": "wrangler types"
   },
   "dependencies": {
+    "@epic-web/client-hints": "^1.3.5",
     "@radix-ui/react-slot": "^1.1.0",
     "@remix-run/cloudflare": "^2.14.0",
     "@remix-run/react": "^2.14.0",


### PR DESCRIPTION
added client hints to enhance server side rendering and prevent janky page loads. currently just for gms and gns but can be used for theme selection, prefers reduced motion ect.

closes https://github.com/ryan-aldred/remix-on-cloudflare-worker/issues/13

based on https://www.epicweb.dev/tips/use-client-hints-to-eliminate-content-layout-shift

https://github.com/epicweb-dev/epic-stack/blob/main/app/utils/client-hints.tsx

